### PR TITLE
Fixed OSX/Linux JAX-RX startup script

### DIFF
--- a/bin/basexjaxrx
+++ b/bin/basexjaxrx
@@ -9,7 +9,7 @@ BASEXAPI=$PWD/../lib/basex-api.jar
 
 # Classpath
 LIB=$PWD/../lib
-CP=$BASEX:$BASEXAPI:$LIB/jax-rx-1.3.jar:$LIB/jetty-6.1.25.jar:$LIB/jetty-util-6.1.25.jar:$LIB/servlet-api-2.5-20081211.jar:$LIB/jersey-server-1.4.jar:$LIB/jersey-core-1.4.jar:$LIB/asm-3.1.jar
+CP=$BASEX:$BASEXAPI:$LIB/jax-rx-1.3.1.jar:$LIB/jetty-6.1.25.jar:$LIB/jetty-util-6.1.25.jar:$LIB/servlet-api-2.5-20081211.jar:$LIB/jersey-server-1.4.jar:$LIB/jersey-core-1.4.jar:$LIB/asm-3.1.jar
 
 # Options for virtual machine
 VM=-Xmx512m


### PR DESCRIPTION
Classpath pointed to old version of jax-rx.jar

Thanks Lukas L. for reporting.
