### PR TITLE
[ADD] BaseX Server systemd service file.

### DIFF
--- a/linux/basexserver.service
+++ b/linux/basexserver.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BaseX database server
+
+[Service]
+User=basex
+Group=basex
+WorkingDirectory=/var/basex
+ProtectSystem=full
+ExecStart=/usr/bin/basexserver
+ExecStop=/usr/bin/basexserver stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This service file starts BaseX Server with user "basex.basex" in working directory /var/basex. This means linux installation scripts must ensure that the user basex with group basex exists, as well as the directory /var/basex with permissions 644, owner user basex and owner group basex. All BaseX 8.2.1 RPM packages ( http://download.opensuse.org/repositories/home:/basex:/opensuse/ ) include the service file and create the user, the group and the home directory. Service file is tested to work under Fedora 22.