### PR TITLE
Python build no submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.DS_Store
 *.swp
 *.out
+*.pyc
 
 # Java classfiles
 *.class
@@ -12,3 +13,7 @@
 /release
 
 /mac/dist/BaseX.app/
+
+/python/dist
+/python/build
+/python/*.egg-info/

--- a/python/BaseXClient/__init__.py
+++ b/python/BaseXClient/__init__.py
@@ -1,0 +1,4 @@
+
+def main():
+    """Entry point for the application script"""
+    print("Call your main application code here")

--- a/python/BaseXClient/package_data.dat
+++ b/python/BaseXClient/package_data.dat
@@ -1,0 +1,1 @@
+some data

--- a/python/LICENSE.txt
+++ b/python/LICENSE.txt
@@ -1,0 +1,33 @@
+====================================================== BASEX LICENSE ===
+
+Copyright (c) 2005-12 BaseX Team <info@basex.org>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+========================================================================

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,9 @@
+# Include the license file
+include LICENSE.txt
+
+# Include the data files
+recursive-include data *
+
+# If using Python 2.6 or less, then have to include package data, even though
+# it's already declared in setup.py
+# include sample/*.dat

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,7 @@
+SOURCES=BaseXClient/BaseXClient.py
+
+BaseXClient/BaseXClient.py:
+	cd BaseXClient && curl -O https://raw.githubusercontent.com/BaseXdb/basex/master/basex-api/src/main/python/BaseXClient.py
+
+all: $(SOURCES)
+	python setup.py bdist_wheel

--- a/python/README.rst
+++ b/python/README.rst
@@ -1,0 +1,148 @@
+A Python Client API for BaseX
+=============================
+
+BaseX is a light-weight, high-performance and scalable XML Database engine and XPath/XQuery 3.1 Processor, which includes full support for the W3C Update and Full Text extensions. An interactive and user-friendly GUI frontend gives you great insight into your XML documents.
+
+The Python Client provides access to the BaseX features from within python. This enables records to be read and written from/to BaseX. Full support for FLOWR is provided as well as DB admin features.
+
+----
+
+Creating a new database
+-----------------------
+
+.. code:: python
+
+    # -*- coding: utf-8 -*-
+    # This example shows how new databases can be created.
+    #
+    # Documentation: http://docs.basex.org/wiki/Clients
+    #
+    # (C) BaseX Team 2005-12, BSD License
+
+    import BaseXClient
+
+    # create session
+    session = BaseXClient.Session('localhost', 1984, 'admin', 'admin')
+
+    try:
+        # create new database
+        session.create("database", "<x>Hello World!</x>")
+        print(session.info())
+
+        # run query on database
+        print("\n" + session.execute("xquery doc('database')"))
+
+        # drop database
+        session.execute("drop db database")
+        print(session.info())
+
+    finally:
+        # close session
+        if session:
+            session.close()
+
+
+
+Query Example
+-------------
+
+.. code:: python
+
+    # -*- coding: utf-8 -*-
+    # This example shows how queries can be executed in an iterative manner.
+    # Iterative evaluation will be slower, as more server requests are performed.
+    #
+    # Documentation: http://docs.basex.org/wiki/Clients
+    #
+    # (C) BaseX Team 2005-12, BSD License
+
+    import BaseXClient
+
+    # create session
+    session = BaseXClient.Session('localhost', 1984, 'admin', 'admin')
+
+    try:
+        # create query instance
+        input = "for $i in 1 to 10 return <xml>Text { $i }</xml>"
+        query = session.query(input)
+
+        # loop through all results
+        for typecode, item in query.iter():
+            print("typecode=%d" % typecode)
+            print("item=%s" % item)
+
+        # close query object
+        query.close()
+
+    finally:
+        # close session
+        if session:
+            session.close()
+
+Add Example
+-----------
+
+.. code:: python
+
+    # -*- coding: utf-8 -*-
+    # This example shows how new databases can be created.
+    #
+    # Documentation: http://docs.basex.org/wiki/Clients
+    #
+    # (C) BaseX Team 2005-12, BSD License
+
+    import BaseXClient
+
+    # create session
+    session = BaseXClient.Session('localhost', 1984, 'admin', 'admin')
+
+    try:
+        # create new database
+        session.create("database", "<x>Hello World!</x>")
+        print(session.info())
+
+        # run query on database
+        print("\n" + session.execute("xquery doc('database')"))
+
+        # drop database
+        session.execute("drop db database")
+        print(session.info())
+
+    finally:
+        # close session
+        if session:
+            session.close()
+
+Query Bind Example
+------------------
+
+.. code:: python
+
+    # -*- coding: utf-8 -*-
+    # This example shows how new databases can be created.
+    #
+    # Documentation: http://docs.basex.org/wiki/Clients
+    #
+    # (C) BaseX Team 2005-12, BSD License
+
+    import BaseXClient
+
+    # create session
+    session = BaseXClient.Session('localhost', 1984, 'admin', 'admin')
+
+    try:
+        # create new database
+        session.create("database", "<x>Hello World!</x>")
+        print(session.info())
+
+        # run query on database
+        print("\n" + session.execute("xquery doc('database')"))
+
+        # drop database
+        session.execute("drop db database")
+        print(session.info())
+
+    finally:
+        # close session
+        if session:
+            session.close()

--- a/python/data/data_file
+++ b/python/data/data_file
@@ -1,0 +1,1 @@
+some data

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,114 @@
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='BaseXClient',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='8.4.4',
+
+    description='A client API for BaseX',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='http://basex.org',
+
+    # Author details
+    author='Ben Greene',
+    author_email='BenJGreene+basex@gmail.com',
+
+    # Choose your license
+    license='BSD',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 5 - Production/Stable',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: BSD License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    # What does your project relate to?
+    keywords='basex xml client',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:
+    #   py_modules=["my_module"],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[],
+
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). You can install these using the following syntax,
+    # for example:
+    # $ pip install -e .[dev,test]
+    extras_require={
+        'dev': ['check-manifest'],
+        'test': ['coverage'],
+    },
+
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.  If using Python 2.6 or less, then these
+    # have to be included in MANIFEST.in as well.
+    package_data={
+        'BaseXClient': [],
+    },
+
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    # data_files=[('my_data', ['data/data_file'])],
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    entry_points={
+        'console_scripts': [
+            'sample=sample:main',
+        ],
+    },
+)

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,3 @@
+# the inclusion of the tests module is not meant to offer best practices for
+# testing in general, but rather to support the `find_packages` example in
+# setup.py that excludes installing the "tests" package

--- a/python/tests/test_simple.py
+++ b/python/tests/test_simple.py
@@ -1,0 +1,7 @@
+# the inclusion of the tests module is not meant to offer best practices for
+# testing in general, but rather to support the `find_packages` example in
+# setup.py that excludes installing the "tests" package
+
+
+def test_success():
+    assert True

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,0 +1,35 @@
+# this file is *not* meant to cover or endorse the use of tox or pytest or
+# testing in general,
+#
+#  It's meant to show the use of:
+#
+#  - check-manifest
+#     confirm items checked into vcs are in your sdist
+#  - python setup.py check (using the readme_renderer extension)
+#     confirms your long_description will render correctly on pypi
+#
+#  and also to help confirm pull requests to this project.
+
+[tox]
+envlist = py{26,27,33,34}
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+deps =
+    check-manifest
+    {py27,py33,py34}: readme_renderer
+    flake8
+    pytest
+commands =
+    check-manifest --ignore tox.ini,tests*
+    # py26 doesn't have "setup.py check"
+    {py27,py33,py34}: python setup.py check -m -r -s
+    flake8 .
+    py.test tests
+[flake8]
+exclude = .tox,*.egg,build,data
+select = E,W,F


### PR DESCRIPTION
I added a new directory at the bottom level of basex-dist where i build the python packaging ready to upload to pypi.

The build process is started by running `make all`
As a first step it fetches the python package from the basex repository into the correct place so does not replicate code, but expects the structure for basex to remain consistent.

I created a package in pypi (https://pypi.python.org/pypi/BaseXClient) so that BaseXClient will be accessible using `pip install BaseXClient`