### PR TITLE
Sign the Windows installer via SignPath

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Keep the GitHub Actions used by the release workflow up to date.
+# Dependabot scans .github/workflows/ and opens PRs when a newer action
+# release is available (e.g. the Node runtime bumps).
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Bundle all action bumps into a single PR instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+# Build the full BaseX release set via release.pl and sign the Windows installer
+# through the SignPath GitHub Actions connector (test-signing until the OV cert
+# is issued). Needs secret SIGNPATH_API_TOKEN; without it, signing is skipped.
+
+name: Build and sign release
+
+on:
+  workflow_dispatch:
+    inputs:
+      basex-ref:
+        description: "Branch/tag/SHA of BaseXdb/basex to build against"
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  actions: read   # SignPath connector reads the uploaded artifact
+
+jobs:
+  build-release:
+    runs-on: windows-latest
+
+    env:
+      # SignPath (BaseX [OSS]); switch to release-signing once the OV cert is issued.
+      SIGNPATH_ORGANIZATION_ID: 060434fa-7e50-47ef-a8ea-8e056eb58164
+      SIGNPATH_PROJECT_SLUG: basex
+      SIGNPATH_POLICY_SLUG: test-signing
+      SIGNPATH_ARTIFACT_CONFIG_SLUG: initial   # <zip-file> wrapping <pe-file path="*.exe">
+      HAS_SIGNPATH_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+
+    steps:
+      - name: Checkout basex-dist
+        uses: actions/checkout@v7
+        with:
+          path: basex-dist
+
+      # basex must sit next to basex-dist (release.pl references ../basex)
+      - name: Checkout basex
+        uses: actions/checkout@v7
+        with:
+          repository: BaseXdb/basex
+          ref: ${{ github.event.inputs.basex-ref }}
+          path: basex
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install Perl modules used by release.pl
+        shell: cmd
+        run: cpanm --notest Archive::Zip File::Copy::Recursive || cpan -T Archive::Zip File::Copy::Recursive
+
+      - name: Build all release artifacts
+        shell: cmd
+        working-directory: basex-dist
+        run: perl release.pl
+
+      # Upload only the installer; its zip feeds the connector (matches path="*.exe")
+      - name: Upload installer for signing
+        id: upload-installer
+        if: env.HAS_SIGNPATH_TOKEN == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: installer-to-sign
+          path: basex-dist/release/*.exe
+          if-no-files-found: error
+          retention-days: 1   # transient signer input
+
+      - name: Submit signing request to SignPath
+        if: env.HAS_SIGNPATH_TOKEN == 'true'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIG_SLUG }}
+          github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      # Move the signed installer back into release/
+      - name: Replace installer with signed version
+        if: env.HAS_SIGNPATH_TOKEN == 'true'
+        shell: pwsh
+        run: |
+          $signed = Get-ChildItem signed/*.exe | Select-Object -First 1
+          Copy-Item -Force $signed.FullName (Join-Path "basex-dist/release" $signed.Name)
+          $sig = Get-AuthenticodeSignature (Join-Path "basex-dist/release" $signed.Name)
+          "Status : $($sig.Status)"
+          "Signer : $($sig.SignerCertificate.Subject)"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: BaseX-release
+          path: basex-dist/release/
+          if-no-files-found: error

--- a/release.pl
+++ b/release.pl
@@ -202,29 +202,8 @@ sub exe {
 
   # create installer
   system("$nsis win/tmp.nsi");
-  #sign();
   move("win/Setup.exe", "release/BaseX.exe");
   unlink("win/tmp.nsi");
-}
-
-# signs the installer
-sub sign {
-  print "* Sign EXE file\n";
-  system("signtool sign /a /tr http://time.certum.pl/ /td SHA256 /fd SHA256 win/Setup.exe");
-  if ($? == -1) {
-    # failed to execute the command
-    print "Failed to execute: $!\n";
-    exit 1;
-  } elsif ($? & 127) {
-    # command died with signal
-    printf "Command died with signal %d, %s coredump\n",
-      ($? & 127),  ($? & 128) ? 'with' : 'without';
-    exit 1;
-  } elsif ($? >> 8) {
-    # command exited with non-zero status
-    printf "Command exited with errorlevel %d\n", $? >> 8;
-    exit 1;
-  }
 }
 
 # write PAD file
@@ -261,12 +240,24 @@ sub pad {
 sub finish {
   print "* Finish release\n";
 
-  (my $v = $version) =~ s/\.//g;
-  move("release/BaseX.app.zip", "release/BaseX$v.app.zip");
-  move("release/BaseX.zip", "release/BaseX$v.zip");
-  move("release/BaseX.jar", "release/BaseX$v.jar");
-  move("release/basex.war", "release/BaseX$v.war");
-  move("release/BaseX.exe", "release/BaseX$v.exe");
+  # artifact base name: "BaseX124" for a release, "BaseX130-20260706.234438"
+  # for a snapshot (a version with a "-SNAPSHOT" qualifier gets a timestamp).
+  (my $digits = $version) =~ s/-.*//;   # strip qualifier: 13.0-SNAPSHOT -> 13.0
+  $digits =~ s/\.//g;                    # remove dots:      13.0        -> 130
+  my $name = "BaseX$digits";
+  if($version =~ /-/) {
+    my ($sec, $min, $hou, $day, $mon, $yr) = localtime();
+    $name .= sprintf("-%04d%02d%02d.%02d%02d%02d",
+      $yr + 1900, $mon + 1, $day, $hou, $min, $sec);
+  }
+  print "* Artifact name: $name\n";
+
+  # BaseX.app.zip is built on macOS only; skip the rename when it is absent.
+  move("release/BaseX.app.zip", "release/$name.app.zip") if -e "release/BaseX.app.zip";
+  move("release/BaseX.zip", "release/$name.zip");
+  move("release/BaseX.jar", "release/$name.jar");
+  move("release/basex.war", "release/$name.war");
+  move("release/BaseX.exe", "release/$name.exe");
   unlink("release/basex-api-$version.jar");
   rmtree("release/basex");
   rmtree("release/bin");


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the full release set (installer, zip, jar, war) with `release.pl` and Authenticode-signs the Windows installer through the SignPath GitHub Actions connector. Wired to the **BaseX [OSS]** SignPath org, `test-signing` policy (self-signed test cert) for now. A signing secret is needed for this to work, which will be communicated separately. Without the secret, the workflow still builds and uploads all artifacts - just unsigned.

### Files
- `.github/workflows/release.yml`: build, sign installer, upload artifacts
- `release.pl`: build the full set; name artifacts `BaseX<ver>.*` (release) and `BaseX<ver>-<YYYYMMDD>.<HHMMSS>.*` (snapshot)
- `.github/dependabot.yml`: keep the workflow's actions up to date

### What needs to be configured in BaseXdb/basex-dist (not contained in this PR)
- [x] **Secret `SIGNPATH_API_TOKEN`** = the SignPath **"CI builds"** user's API token (obtained from user details page - API token). Until set, signing is skipped. Will be communicated separately.
- [x] **Install the SignPath GitHub App** on this repo (github.com/apps/signpath - Configure - BaseXdb - select `basex-dist`). Required for `release-signing` (origin verification).
- [x] **Merge to the default branch (`master`)** so the manual "Run workflow" button appears - `workflow_dispatch` only shows on the default branch.
- [x] *(optional)* Enable **Dependabot** in repo settings so `dependabot.yml` takes effect.

SignPath identifiers are in the workflow `env`:
- org `060434fa-7e50-47ef-a8ea-8e056eb58164`,
- project `basex`,
- policy `test-signing`,
- artifact config `initial`.

### Verifying a test-signed build
Run **Actions - Build and sign release**, download `BaseX-release`, and check the installer. It shows as "Unknown Publisher" until you import the attached test certificate into *Trusted Root Certification Authorities* (because it's self-signed). `Get-AuthenticodeSignature <installer>.exe` shows the signer.

[test_certificate_2026.zip](https://github.com/user-attachments/files/30467674/test_certificate_2026.zip)

### Going to production (later)
Once this setup is working in BaseXDB/basex-dist, we can ask SignPath to review. We also need to ask them for adding basex-dist as a secondary repo. Once SignPath issues the release certificate (`release-signing`, currently in status "CSR pending"): change `SIGNPATH_POLICY_SLUG` to `release-signing`. Expect `release-signing` to require manual approval of each signing request.

### Changes to SignPath configuration

These changes have been done to the preconfigured `BaseX [OSS]` orgnanization and `basex` project:
- the "Artifact configuration" got a description of "Windows installer" and it has been changed to `zip-file`:

  ```
  <?xml version="1.0" encoding="utf-8" ?>
  <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
    <zip-file>
      <pe-file path="*.exe">
        <authenticode-sign/>
      </pe-file>
    </zip-file>
  </artifact-configuration>
  ```
- an API token was generated for user "CI Builds" (the `SIGNPATH_API_TOKEN` to be set on the GitHub project)
